### PR TITLE
Fix Android manifest instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ add the following to your ```AndroidManifest.xml``` file
  <meta-data
            android:name=
                "com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
-           android:value="GoogleCastOptionsProvider" />
+           android:value="com.felnanuke.google_cast.GoogleCastOptionsProvider" />
 
   <service
   android:name="com.google.android.gms.cast.framework.media.MediaNotificationService"


### PR DESCRIPTION
Cheers for the awesome package,

I am in the middle of integrating it and I noticed I have to use the full namespace for Android manifest. The readme is a bit confusing in this regard so I fixed it to avoid future confusion.