### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,7 @@ fix /android/app/src/main/AndroidManifest.xml and add
 - Bump version and update dependency versions in pubspec.yaml.
 - Update SDK constraints in both main and example pubspec files for compatibility with latest Flutter.
 - Add conditional namespace configuration in android/build.gradle for compatibility with the latest Gradle and Android Studio.
+
+## 1.0.1
+- Update README example to use fully qualified provider class name for Android manifest integration
+- Clarify the android:value meta-data entry with complete package path to prevent ambiguity when registering the options provider

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chrome_cast
 description: this is a flutter plugin for google cast
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/felnanuke2/flutter_google_cast
 license: BSD-3-Clause
 


### PR DESCRIPTION
- Update README example to use fully qualified provider class name for Android manifest integration
- Clarify the android:value meta-data entry with complete package path to prevent ambiguity when registering the options provider