### PR TITLE
adding the stop method for audio which is missing RemoteMediaClientMe…

### DIFF
--- a/android/src/main/kotlin/com/felnanuke/google_cast/RemoteMediaClientMethodChannel.kt
+++ b/android/src/main/kotlin/com/felnanuke/google_cast/RemoteMediaClientMethodChannel.kt
@@ -225,6 +225,10 @@ class RemoteMediaClientMethodChannel : FlutterPlugin, MethodChannel.MethodCallHa
                 pause()
                 result.success(true)
             }
+            "stop" -> {
+                stop()
+                result.success(true)
+            }
 
             else -> result.notImplemented()
         }
@@ -321,6 +325,10 @@ class RemoteMediaClientMethodChannel : FlutterPlugin, MethodChannel.MethodCallHa
     private fun play() {
         currentRemoteMediaClient?.play()
 
+    }
+
+    private fun stop() {
+        currentRemoteMediaClient?.stop()
     }
 
     private fun queueLoadItems(arguments: Map<String, Any?>) {


### PR DESCRIPTION
…thodChannel.kt

The audio stop method is missing in the remote casting client, if there is any issue in mine you can just explain.