### PR TITLE
Unknown track languages in m3u8 playlists cause player state events to be lost

### DIFF
--- a/lib/common/rfc5646_language.dart
+++ b/lib/common/rfc5646_language.dart
@@ -720,6 +720,7 @@ enum Rfc5646Language {
   /// Returns the corresponding [Rfc5646Language] enum value.
   /// Throws a [StateError] if no matching language code is found.
   factory Rfc5646Language.fromMap(String value) {
-    return values.firstWhere((element) => element.toString() == value);
+    return values.firstWhere((element) => element.toString() == value,
+        orElse: () => english);
   }
 }


### PR DESCRIPTION
Return a default language instead of throw a `StateError` in `Rfc5646Language.fromMap()`.

As an example, Vimeo HLS playlists return "unc" as the audio track language if not explicitly defined. This causes the `Rfc5646Language.fromMap()` factory to throw an error. This, in turn, causes player state events to be lost from the method channel (especially `playing` events once the video is loaded and buffered).

I'm open to other ways this could be fixed (catch the `StateError` and return `null`? I don't think null-safe constructors can do that anymore), but this seemed a reasonable option.