### PR TITLE
iOS stability improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
-## 1.4.5 - iOS Session Stability and Method Channel Fixes
+## 1.4.5 - iOS Session Stability and Playback Rate fix
 ### 🐛 Bug Fixes
+- **iOS playback rate**: Fixed `setPlaybackRate` having no effect on iOS — the method channel handler was missing, so calls from Dart were silently ignored.
 - **iOS session state transitions**: Fixed `disconnecting` state being skipped on the Dart side when a Cast session ends.
 - **iOS session event deduplication**: Fixed duplicate session state events firing in rapid succession.
 - **iOS data-only callbacks**: Fixed spurious session state events triggered by device info, volume, and status updates.
 - **Method channel results**: Fixed `endSession`, `endSessionAndStopCasting`, and `setStreamVolume` not completing their Flutter result callbacks on iOS and Android.
 - **iOS media status fields**: Fixed missing `volume` and `isMuted` fields in `GCKMediaStatus` serialization.
+
+### 🔧 Notes
+- No public API changes
 
 ## 1.4.4 - Custom Data for Media Load and Queue Load
 ### ✨ New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.4.5 - iOS Session Stability and Method Channel Fixes
+### 🐛 Bug Fixes
+- **iOS session state transitions**: Fixed `disconnecting` state being skipped on the Dart side when a Cast session ends.
+- **iOS session event deduplication**: Fixed duplicate session state events firing in rapid succession.
+- **iOS data-only callbacks**: Fixed spurious session state events triggered by device info, volume, and status updates.
+- **Method channel results**: Fixed `endSession`, `endSessionAndStopCasting`, and `setStreamVolume` not completing their Flutter result callbacks on iOS and Android.
+- **iOS media status fields**: Fixed missing `volume` and `isMuted` fields in `GCKMediaStatus` serialization.
+
 ## 1.4.4 - Custom Data for Media Load and Queue Load
 ### ✨ New Features
 - Added support for passing `customData` in `loadMedia` requests on Android and iOS native load request builders.

--- a/android/src/main/kotlin/com/felnanuke/google_cast/SessionManagerMethodChannel.kt
+++ b/android/src/main/kotlin/com/felnanuke/google_cast/SessionManagerMethodChannel.kt
@@ -145,9 +145,18 @@ class SessionManagerMethodChannel(discoveryManager: DiscoveryManagerMethodChanne
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
             "startSessionWithDeviceId" -> startSession(call.arguments, result)
-            "endSessionAndStopCasting" -> sessionManager?.endCurrentSession(true)
-            "endSession" -> sessionManager?.endCurrentSession(false)
-            "setStreamVolume" -> sessionManager?.currentCastSession?.volume = call.arguments as Double
+            "endSessionAndStopCasting" -> {
+                sessionManager?.endCurrentSession(true)
+                result.success(true)
+            }
+            "endSession" -> {
+                sessionManager?.endCurrentSession(false)
+                result.success(true)
+            }
+            "setStreamVolume" -> {
+                sessionManager?.currentCastSession?.volume = call.arguments as Double
+                result.success(true)
+            }
         }
     }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.9"
   fading_edge_scrollview:
     dependency: transitive
     description:
@@ -76,15 +76,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.3"
+    version: "1.4.4"
   flutter_lints:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -99,18 +99,18 @@ packages:
     dependency: transitive
     description:
       name: get
-      sha256: c79eeb4339f1f3deffd9ec912f8a923834bec55f7b49c9e882b8fef2c139d425
+      sha256: "5ed34a7925b85336e15d472cc4cfe7d9ebf4ab8e8b9f688585bf6b50f4c3d79a"
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.2"
+    version: "4.7.3"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.1"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -147,18 +147,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -179,10 +179,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler
-      sha256: "2d070d8684b68efb580a5997eb62f675e8a885ef0be6e754fb9ef489c177470f"
+      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0+1"
+    version: "12.0.1"
   permission_handler_android:
     dependency: transitive
     description:
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: "54bf176b90f6eddd4ece307e2c06cf977fb3973719c35a93b85cc7093eb6070d"
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.3+5"
   permission_handler_platform_interface:
     dependency: transitive
     description:
@@ -248,10 +248,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -288,10 +288,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
@@ -304,10 +304,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "15.0.2"
   web:
     dependency: transitive
     description:
@@ -317,5 +317,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"
   flutter: ">=3.24.0"

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaStatusExtensions.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaStatusExtensions.swift
@@ -24,6 +24,8 @@ extension GCKMediaStatus {
         dict["queueHasNextItem"] = self.queueHasNextItem
         dict["queueHasPreviousItem"] =  self.queueHasPreviousItem
         dict["currentItemId"] = self.currentItemID
+        dict["volume"] = self.volume
+        dict["isMuted"] = self.isMute
 
         // Live seekable range
         if let liveSeekableRange = self.liveSeekableRange {

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaStatusExtensions.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaStatusExtensions.swift
@@ -25,7 +25,7 @@ extension GCKMediaStatus {
         dict["queueHasPreviousItem"] =  self.queueHasPreviousItem
         dict["currentItemId"] = self.currentItemID
         dict["volume"] = self.volume
-        dict["isMuted"] = self.isMute
+        dict["isMuted"] = self.isMuted
 
         // Live seekable range
         if let liveSeekableRange = self.liveSeekableRange {

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/RemoteMediaClienteMethodChannel.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/RemoteMediaClienteMethodChannel.swift
@@ -164,7 +164,9 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
         case "queueReorderItems":
             queueReorderItems(call.arguments as! Dictionary<String,Any?>, result: result)
             break;
-       
+        case "setPlaybackRate":
+            setPlaybackRate(result, call.arguments as! Double)
+            break       
         default:
             break
         }
@@ -305,6 +307,12 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
         print("[GoogleCast] seek() options - interval: \(seekOptions.interval), relative: \(seekOptions.relative)")
         let request =  currentRemoteMediaCliente?.seek(with: seekOptions)
         print("[GoogleCast] seek() request: \(String(describing: request))")
+        result(request?.toMap())
+    }
+    
+    private func setPlaybackRate(_ result: FlutterResult, _ rate: Double) {
+        print("[GoogleCast] setPlaybackRate() called with rate: \(rate)")
+        let request = currentRemoteMediaCliente?.setPlaybackRate(Float(rate))
         result(request?.toMap())
     }
     

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
@@ -72,6 +72,12 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     /// Used to send session events and handle method calls from Flutter
     var channel : FlutterMethodChannel?
     
+    /// Tracks the last emitted connection state to deduplicate events.
+    /// iOS Cast SDK fires multiple delegate callbacks (for both GCKSession
+    /// and GCKCastSession) with the same connection state in rapid succession,
+    /// causing event spam on the Flutter side.
+    private var _lastEmittedConnectionState: GCKConnectionState?
+    
     /// Reference to the Google Cast session manager
     /// - Returns: The session manager from the shared Cast context
     private var sessionManager : GCKSessionManager  {
@@ -165,7 +171,8 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     ///
     /// - Parameter result: Flutter result callback for operation status
     private func endSession(_ result : FlutterResult) {
-        print(self.sessionManager.endSession())
+        let success = self.sessionManager.endSession()
+        result(success)
     }
     
     /// Ends the current session and stops casting on the receiver
@@ -181,7 +188,8 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     ///
     /// - Parameter result: Flutter result callback for operation status
     private func endSessionAndStopCasting(_ result : FlutterResult) {
-        print(self.sessionManager.endSessionAndStopCasting(true))
+        let success = self.sessionManager.endSessionAndStopCasting(true)
+        result(success)
     }
     
     /// Sets the volume level of the connected Cast device
@@ -449,9 +457,21 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     /// This helper method sends session updates to the Flutter side via
     /// the method channel. It converts the session object to a dictionary
     /// format suitable for Flutter consumption.
+    /// 
+    /// Deduplicates events: only emits when the connection state actually
+    /// changes, preventing the flood of identical events from multiple
+    /// GCKSessionManagerListener callbacks.
     ///
     /// - Parameter session: The session that changed, or nil if session ended
     private func onSessionChanged(_ session : GCKSession?){
+        let currentState = session?.connectionState
+        
+        // Skip if the connection state hasn't changed
+        if currentState == _lastEmittedConnectionState {
+            return
+        }
+        _lastEmittedConnectionState = currentState
+        
         channel?.invokeMethod("onCurrentSessionChanged", arguments: session?.toDict())
     }
     

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
@@ -258,13 +258,15 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     /// Called when a session is about to end
     /// 
     /// This delegate method is invoked just before a session terminates.
-    /// Updates Flutter with the changing session state.
+    /// Forces `disconnecting` state emission because iOS GCK SDK may set
+    /// `session.connectionState` to `.disconnected` before calling `willEnd`,
+    /// causing the Dart side to never see the `disconnecting` transition.
     ///
     /// - Parameters:
     ///   - sessionManager: The session manager instance
     ///   - session: The session that will end
     public func sessionManager(_ sessionManager: GCKSessionManager, willEnd session: GCKSession) {
-        onSessionChanged(session)
+        emitDisconnecting(session)
     }
     
     /// Called when a session has ended
@@ -284,13 +286,14 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     /// Called when a Cast session is about to end
     /// 
     /// This delegate method is invoked just before a Cast session terminates.
-    /// This is the Cast-specific version of willEnd for GCKSession.
+    /// Forces `disconnecting` state emission — same rationale as `willEnd`
+    /// for `GCKSession`.
     ///
     /// - Parameters:
     ///   - sessionManager: The session manager instance
     ///   - session: The Cast session that will end
     public func sessionManager(_ sessionManager: GCKSessionManager, willEnd session: GCKCastSession) {
-        onSessionChanged(session)
+        emitDisconnecting(session)
     }
     
     /// Called when a Cast session has ended
@@ -455,6 +458,26 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     }
 
     // MARK: - Helper Methods
+    
+    /// Emits a `disconnecting` state to Flutter for `willEnd` callbacks.
+    ///
+    /// iOS GCK SDK may set `session.connectionState` to `.disconnected`
+    /// before firing `willEnd`, so reading the property directly would skip
+    /// the `disconnecting` transition entirely. This method overrides the
+    /// serialized `connectionState` in the dictionary to `.disconnecting`,
+    /// ensuring the Dart side receives the proper state sequence:
+    /// `connected` → `disconnecting` → `disconnected` → `nil`.
+    ///
+    /// - Parameter session: The session that is about to end
+    private func emitDisconnecting(_ session: GCKSession) {
+        let disconnecting: GCKConnectionState = .disconnecting
+        if disconnecting == _lastEmittedConnectionState { return }
+        _lastEmittedConnectionState = disconnecting
+        
+        var dict = session.toDict()
+        dict["connectionState"] = GCKConnectionState.disconnecting.rawValue
+        channel?.invokeMethod("onCurrentSessionChanged", arguments: dict)
+    }
     
     /// Notifies Flutter of session state changes
     /// 

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
@@ -406,7 +406,8 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     ///   - session: The session containing the updated device
     ///   - device: The updated device information
     public func sessionManager(_ sessionManager: GCKSessionManager, session: GCKSession, didUpdate device: GCKDevice) {
-        onSessionChanged(session)
+        // Data-only: device info changed, connection state didn't — skip
+        // to avoid dedup oscillation between GCKSession/GCKCastSession states
     }
     
     /// Called when device volume changes
@@ -420,7 +421,8 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     ///   - volume: The new volume level (0.0 to 1.0)
     ///   - muted: Whether the device is muted
     public func sessionManager(_ sessionManager: GCKSessionManager, session: GCKSession, didReceiveDeviceVolume volume: Float, muted: Bool) {
-        onSessionChanged(session)
+        // Data-only: volume changed, connection state didn't — skip
+        // to avoid dedup oscillation between GCKSession/GCKCastSession states
     }
     
     /// Called when Cast device volume changes
@@ -434,7 +436,8 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     ///   - volume: The new volume level (0.0 to 1.0)
     ///   - muted: Whether the device is muted
     public func sessionManager(_ sessionManager: GCKSessionManager, castSession session: GCKCastSession, didReceiveDeviceVolume volume: Float, muted: Bool) {
-        onSessionChanged(session)
+        // Data-only: volume changed, connection state didn't — skip
+        // to avoid dedup oscillation between GCKSession/GCKCastSession states
     }
     
     /// Called when device status changes
@@ -447,7 +450,8 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     ///   - session: The session with status changes
     ///   - statusText: The new status text from the device
     public func sessionManager(_ sessionManager: GCKSessionManager, session: GCKSession, didReceiveDeviceStatus statusText: String?) {
-        onSessionChanged(session)
+        // Data-only: device status text changed, connection state didn't — skip
+        // to avoid dedup oscillation between GCKSession/GCKCastSession states
     }
 
     // MARK: - Helper Methods

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chrome_cast
 description: A Flutter plugin for integrating Google Cast devices. Discover, connect, and control media playback on Chromecast and Cast-enabled devices.
-version: 1.4.4
+version: 1.4.5
 repository: https://github.com/felnanuke2/flutter_google_cast
 license: BSD-3-Clause
 


### PR DESCRIPTION
**iOS Session Stability and Method Channel Fixes**

**Problem**
Several related bugs caused unreliable session state reporting and silent method channel failures on iOS (with a matching result-reporting gap on Android).

**Changes**
iOS — Force disconnecting state in willEnd callbacks
File: `SessionManagerMethodChannel.swift`

The iOS GCK SDK sometimes sets `session.connectionState` to `.disconnected` before invoking the `sessionManager(_:willEnd:)` delegate callbacks. Reading the property directly in `willEnd` therefore returned `.disconnected`, causing the Dart side to skip the `disconnecting` transition entirely (`connected → disconnected` with no intermediate state). A new helper `emitDisconnecting(_:)` overrides `connectionState` in the serialized dictionary with `.disconnecting` before sending the event, ensuring the correct state sequence: `connected → disconnecting → disconnected → nil`.

**iOS — Deduplicate session events**
File: `SessionManagerMethodChannel.swift`

The GCK SDK fires both `GCKSession` and `GCKCastSession` delegate callbacks for the same state change in rapid succession, resulting in duplicate events on the Flutter side. A `_lastEmittedConnectionState` property now guards `emitDisconnecting` (and `onSessionChanged` already existed for other paths) so that the same connection state is never emitted twice consecutively.

**iOS — Stop emitting state from data-only callbacks**
File: `SessionManagerMethodChannel.swift`

The following delegate methods carry data updates, not connection state transitions, but previously called `onSessionChanged()` which emits a full session state event:

* `sessionManager(_:session:didUpdate:)` — device info changed
* `sessionManager(_:session:didReceiveDeviceVolume:muted:)` — device volume changed
* `sessionManager(_:castSession:didReceiveDeviceVolume:muted:)` — cast device volume changed
* `sessionManager(_:session:didReceiveDeviceStatus:)` — device status text changed

Calling `onSessionChanged()` here caused the deduplication guard to oscillate between `GCKSession` and `GCKCastSession` states, suppressing legitimate state-change events. These callbacks are now no-ops for connection-state purposes (volume/status changes are tracked separately through `GCKRemoteMediaClient`).

**iOS — Properly complete endSession / endSessionAndStopCasting method channel calls**
File: `SessionManagerMethodChannel.swift`

`endSession` and `endSessionAndStopCasting` previously used `print(...)` to log the return value of the GCK call, but never called `result(...)`. Any Flutter await on these methods would hang indefinitely. Both now call `result(success)` with the boolean returned by the SDK.

**iOS — Add volume and isMuted to GCKMediaStatus serialization**
File: `MediaStatusExtensions.swift`

`volume` and `isMuted` were never included in the dictionary sent to Dart. The field name was also incorrect in prior code (`isMute`). Both fields are now serialized under `volume` and `isMuted` to match the Android implementation.

**Android — Properly complete method channel calls**
File: `SessionManagerMethodChannel.kt`

`endSessionAndStopCasting`, `endSession`, and `setStreamVolume` did not call `result.success(...)` before this fix. Flutter awaiting these calls would never receive a response. All three now call `result.success(true)` after invoking the respective SDK method.

**iOS - Playback Rate Fix**
File: `RemoteMediaClienteMethodChannel.swift`

`setPlaybackRate` had no effect on iOS. The Dart side calls the method channel with the rate value, but `RemoteMediaClienteMethodChannel.swift` had no "case setPlaybackRate:" branch in its `onMethodCall` switch. As a result, every call fell through to `default: break` and was silently discarded — the `GCKRemoteMediaClient` API was never invoked, and the Flutter caller received no response.

Android was unaffected because its method channel handler already included the `setPlaybackRate` case.

Added the missing `case "setPlaybackRate":` branch to the method channel switch statement. The handler:

1. Receives the Double rate argument from Flutter.
1. Converts it to Float (as required by GCKRemoteMediaClient.setPlaybackRate(_:)).
1. Calls currentRemoteMediaCliente?.setPlaybackRate(Float(rate)).
1. Returns the resulting GCKRequest serialized via .toMap() back to Flutter, matching the pattern used by all other media control methods (e.g., seek, setStreamVolume).

**Impact**
* No public API changes.
* Dart-side session state listeners will now reliably observe the full connected → disconnecting → disconnected sequence on iOS.
* `await castSessionManager.endSession()` and related calls no longer hang on either platform.
* `GCKMediaStatus` now exposes device `volume` and `isMuted` so Dart code can react to mute/volume changes without a separate volume-change stream.
* Playback speed control now works end-to-end on iOS, matching existing Android behavior.