### PR TITLE
Fix Android Cast session init and discovery for app-specific receiver ID

### DIFF
--- a/android/src/main/kotlin/com/felnanuke/google_cast/CastContextMethodChannel.kt
+++ b/android/src/main/kotlin/com/felnanuke/google_cast/CastContextMethodChannel.kt
@@ -168,19 +168,41 @@ class CastContextMethodChannel : FlutterPlugin, MethodChannel.MethodCallHandler 
         try {
             val map = arguments as HashMap<*, *>
             val optionsBuilder = CastOptions.Builder()
-            optionsBuilder.setReceiverApplicationId(map["appId"] as String)
+            val appId = map["appId"] as String
+            optionsBuilder.setReceiverApplicationId(appId)
             val launcherOptions = LaunchOptions.Builder().setAndroidReceiverCompatible(true).build()
             optionsBuilder.setLaunchOptions(launcherOptions)
             optionsBuilder.setResumeSavedSession(true)
             optionsBuilder.setEnableReconnectionService(true)
             GoogleCastOptionsProvider.options = optionsBuilder.build()
-            
+            GoogleCastOptionsProvider.castAppId = appId
+
             // Store the stopCastingOnAppTerminated option
             val stopCastingOnAppTerminated = map["stopCastingOnAppTerminated"] as? Boolean ?: false
             GoogleCastOptionsProvider.stopCastingOnAppTerminated = stopCastingOnAppTerminated
             Log.d(TAG, "stopCastingOnAppTerminated set to: $stopCastingOnAppTerminated")
             
-            CastContext.getSharedInstance(appContext).sessionManager.addSessionManagerListener(sessionManagerMethodChannel)
+            // Prefer the no-arg overload so we don't try to re-initialise a
+            // CastContext that is already running (e.g. when the app uses the
+            // manifest OPTIONS_PROVIDER_CLASS_NAME for auto-init).  Only fall
+            // back to the context overload when the SDK isn't initialised yet.
+            val castContext = try {
+                CastContext.getSharedInstance()
+            } catch (_: IllegalStateException) {
+                CastContext.getSharedInstance(appContext)
+            }
+            castContext?.sessionManager?.addSessionManagerListener(sessionManagerMethodChannel)
+
+            // If a Cast session is already active when the listener is registered
+            // (e.g. reconnecting to a previously established session), onSessionStarted
+            // will never fire. Call startListen() directly so the RemoteMediaClient
+            // callback chain is wired up regardless.
+            if (castContext?.sessionManager?.currentCastSession != null) {
+                Log.d(TAG, "setSharedInstance: active session found — wiring up listeners and notifying Dart")
+                sessionManagerMethodChannel.startListenIfNeeded()
+                sessionManagerMethodChannel.notifyCurrentSession()
+            }
+
             result.success(true)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to set shared instance", e)

--- a/android/src/main/kotlin/com/felnanuke/google_cast/DiscoveryManagerMethodChannel.kt
+++ b/android/src/main/kotlin/com/felnanuke/google_cast/DiscoveryManagerMethodChannel.kt
@@ -161,8 +161,17 @@ class DiscoveryManagerMethodChannel : FlutterPlugin, MethodChannel.MethodCallHan
 
     private fun startDiscovery() {
         router.removeCallback(routerCallBack)
+
+        // Include the app-specific Cast category alongside the generic one.
+        // The Cast SDK's internal MediaRouter callback only starts a session
+        // for routes that match categoryForCast(appId) — using only
+        // categoryForRemotePlayback() discovers devices but router.selectRoute()
+        // silently fails because the SDK doesn't recognise the route type.
+        val categories = mutableListOf(CastMediaControlIntent.categoryForRemotePlayback())
+        categories.add(CastMediaControlIntent.categoryForCast(GoogleCastOptionsProvider.castAppId))
+
         val selector = MediaRouteSelector.Builder()
-            .addControlCategories(listOf(CastMediaControlIntent.categoryForRemotePlayback()))
+            .addControlCategories(categories)
             .build()
         router.addCallback(
             selector, routerCallBack, MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY
@@ -261,12 +270,18 @@ class DiscoveryManagerMethodChannel : FlutterPlugin, MethodChannel.MethodCallHan
 
     fun selectRoute(id: String) {
         val routes = router?.routes
+        Log.d(TAG, "selectRoute: looking for deviceId=$id in ${routes?.size ?: 0} routes")
         val selectedRoute = routes?.find {
             val device = CastDevice.getFromBundle(it.extras)
-            device?.deviceId == id
+            val match = device?.deviceId == id
+            Log.d(TAG, "  route=${it.name} deviceId=${device?.deviceId} match=$match")
+            match
         }
         if (selectedRoute != null) {
+            Log.d(TAG, "selectRoute: selecting route '${selectedRoute.name}'")
             this.router?.selectRoute(selectedRoute)
+        } else {
+            Log.w(TAG, "selectRoute: no matching route found for deviceId=$id")
         }
     }
 

--- a/android/src/main/kotlin/com/felnanuke/google_cast/GoogleCastOptionsProvider.kt
+++ b/android/src/main/kotlin/com/felnanuke/google_cast/GoogleCastOptionsProvider.kt
@@ -38,6 +38,14 @@ class GoogleCastOptionsProvider : OptionsProvider {
          * Default is false (casting continues after app is closed).
          */
         var stopCastingOnAppTerminated: Boolean = false
+
+        /**
+         * The configured receiver application ID, stored separately because
+         * CastOptions does not expose a getter for it after construction.
+         * Used by DiscoveryManagerMethodChannel to build the Cast-specific
+         * MediaRouteSelector category needed for router.selectRoute() to work.
+         */
+        var castAppId: String = "CC1AD845"
     }
     
     /**

--- a/android/src/main/kotlin/com/felnanuke/google_cast/RemoteMediaClientMethodChannel.kt
+++ b/android/src/main/kotlin/com/felnanuke/google_cast/RemoteMediaClientMethodChannel.kt
@@ -432,8 +432,10 @@ class RemoteMediaClientMethodChannel : FlutterPlugin, MethodChannel.MethodCallHa
     }
 
     fun startListen() {
-        currentRemoteMediaClient?.registerCallback(this)
-        currentRemoteMediaClient?.addProgressListener(this, 500)
+        val client = currentRemoteMediaClient
+        Log.d(TAG, "startListen() — remoteMediaClient=${if (client != null) "non-null" else "NULL"}")
+        client?.registerCallback(this)
+        client?.addProgressListener(this, 500)
     }
 
     fun endListen() {

--- a/android/src/main/kotlin/com/felnanuke/google_cast/SessionManagerMethodChannel.kt
+++ b/android/src/main/kotlin/com/felnanuke/google_cast/SessionManagerMethodChannel.kt
@@ -1,5 +1,7 @@
 package com.felnanuke.google_cast
 
+import android.util.Log
+import com.felnanuke.google_cast.extensions.connectState
 import com.felnanuke.google_cast.extensions.toMap
 import com.google.android.gms.cast.framework.*
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -193,6 +195,7 @@ class SessionManagerMethodChannel(discoveryManager: DiscoveryManagerMethodChanne
     }
 
     override fun onSessionResumed(p0: Session, p1: Boolean) {
+        Log.d(TAG, "onSessionResumed — calling startListen()")
         remoteMediaClientMethodChannel.startListen()
         onSessionChanged()
     }
@@ -206,6 +209,7 @@ class SessionManagerMethodChannel(discoveryManager: DiscoveryManagerMethodChanne
     }
 
     override fun onSessionStarted(session: Session, p1: String) {
+        Log.d(TAG, "onSessionStarted — calling startListen()")
         remoteMediaClientMethodChannel.startListen()
         onSessionChanged()
     }
@@ -221,9 +225,25 @@ class SessionManagerMethodChannel(discoveryManager: DiscoveryManagerMethodChanne
 
     private fun onSessionChanged() {
         val session = sessionManager?.currentCastSession
+        val state = session?.connectState() ?: -1
+        Log.d(TAG, "onSessionChanged: sessionId=${session?.sessionId} connectState=$state isConnected=${session?.isConnected}")
         val map = session?.toMap()
         channel.invokeMethod("onSessionChanged", map)
     }
 
+    /** Called from CastContextMethodChannel when setSharedInstance finds an
+     *  already-active session so onSessionStarted/Resumed will not fire. */
+    fun startListenIfNeeded() {
+        Log.d(TAG, "startListenIfNeeded() — delegating to remoteMediaClientMethodChannel")
+        remoteMediaClientMethodChannel.startListen()
+    }
+
+    /** Push the current session state to the Dart stream immediately.
+     *  Called when an already-active session is detected at setSharedInstance
+     *  time, so the Dart side's BehaviorSubject reflects the real state. */
+    fun notifyCurrentSession() {
+        Log.d(TAG, "notifyCurrentSession() — pushing current session state to Dart")
+        onSessionChanged()
+    }
 
 }


### PR DESCRIPTION
- Add castAppId field to GoogleCastOptionsProvider so the app ID is accessible after CastOptions construction (CastOptions has no getter)
- Add categoryForCast(castAppId) alongside categoryForRemotePlayback in the MediaRouteSelector so router.selectRoute() triggers Cast SDK session callbacks (SDK only fires onSessionStarted for routes matching castAppId)
- Add notifyCurrentSession() / startListenIfNeeded() to push existing session state to Dart when setSharedInstance finds an already-active session
- Wire castAppId assignment and notifyCurrentSession call in CastContextMethodChannel
- Add debug logging to RemoteMediaClientMethodChannel.startListen()