### PR TITLE
Reset connection integrated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.4.6 - iOS Force Session Reset
+### ✨ New Features
+- **`resetSession()` API**: Added a new `resetSession()` method to `GoogleCastSessionManager` that forcefully clears all session and media client state on iOS, enabling a clean reconnect after a stuck or interrupted Cast session.
+
+### 🔧 Notes
+- On Android, `resetSession()` delegates to the existing `endSessionAndStopCasting()` as stale-session issues are not observed on that platform.
+- No other public API changes.
+
 ## 1.4.5 - iOS Session Stability and Playback Rate fix
 ### 🐛 Bug Fixes
 - **iOS playback rate**: Fixed `setPlaybackRate` having no effect on iOS — the method channel handler was missing, so calls from Dart were silently ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 - **`resetSession()` API**: Added a new `resetSession()` method to `GoogleCastSessionManager` that forcefully clears all session and media client state on iOS, enabling a clean reconnect after a stuck or interrupted Cast session.
 
 ### 🔧 Notes
-- On Android, `resetSession()` delegates to the existing `endSessionAndStopCasting()` as stale-session issues are not observed on that platform.
 - No other public API changes.
 
 ## 1.4.5 - iOS Session Stability and Playback Rate fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## 1.4.6 - iOS Force Session Reset
-### ✨ New Features
-- **`resetSession()` API**: Added a new `resetSession()` method to `GoogleCastSessionManager` that forcefully clears all session and media client state on iOS, enabling a clean reconnect after a stuck or interrupted Cast session.
+### New Features
+- Added `resetSession()` to force a clean iOS Cast session reset after interrupted or stuck connections.
 
-### 🔧 Notes
+### Bug Fixes
+- Fixed an iOS crash when the discovered device list changed during connection.
+
+### Notes
 - No other public API changes.
 
 ## 1.4.5 - iOS Session Stability and Playback Rate fix

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.4"
+    version: "1.4.6"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/RemoteMediaClienteMethodChannel.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/RemoteMediaClienteMethodChannel.swift
@@ -416,6 +416,17 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
         updateQueueItems()
     }
     
+    /// Full state cleanup: removes the listener from the media client,
+    /// stops the position timer, and clears the queue.
+    /// Used when forcefully resetting a stuck session.
+    public func cleanUp() {
+        currentRemoteMediaCliente?.remove(self)
+        positionTimer?.invalidate()
+        positionTimer = nil
+        queueItems.removeAll()
+        queueOrder.removeAll()
+    }
+    
     
     public func resumeSession(){
         currentRemoteMediaCliente?.queueFetchItemIDs();

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
@@ -135,6 +135,9 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
         case "endSessionAndStopCasting":
             endSessionAndStopCasting(result)
             break
+        case "resetSession":
+            resetSession(result)
+            break
         case "setDeviceVolume":
             setDeviceVolume(call.arguments as! NSNumber)
             break
@@ -458,6 +461,41 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     }
 
     // MARK: - Helper Methods
+    
+    /// Forcefully resets a stuck session.
+    ///
+    /// 1. Removes the session manager listener so `endSessionAndStopCasting`
+    ///    does not generate spurious callbacks on the Flutter side.
+    /// 2. Cleans up the media client (listener, position timer, queue).
+    /// 3. Force-ends any existing session via `endSessionAndStopCasting(true)`.
+    /// 4. Resets the dedup state (`_lastEmittedConnectionState`).
+    /// 5. Re-adds the session manager listener.
+    /// 6. Emits a `null` session to Flutter.
+    ///
+    /// - Parameter result: Flutter result callback
+    private func resetSession(_ result: FlutterResult) {
+        print("[GoogleCast] resetSession: force-ending session and cleaning up all state")
+        
+        // Remove listener so endSessionAndStopCasting does not fire
+        // willEnd/didEnd and produce stale events on the Flutter side
+        sessionManager.remove(self)
+        
+        // Clean up media client
+        RemoteMediaClienteMethodChannel.instance.cleanUp()
+        
+        // Force-end any existing session
+        if sessionManager.currentSession != nil {
+            sessionManager.endSessionAndStopCasting(true)
+        }
+        
+        // Reset dedup state — the next session will be tracked from scratch
+        _lastEmittedConnectionState = nil
+        
+        // Re-add listener
+        sessionManager.add(self)
+        
+        result(true)
+    }
     
     /// Emits a `disconnecting` state to Flutter for `willEnd` callbacks.
     ///

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
@@ -159,10 +159,23 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     ///
     /// - Parameter deviceIndex: The index of the device in the discovery list
     /// - Returns: `true` if session initiation was successful, `false` otherwise
-    /// - Note: This method only initiates the session; actual connection status 
+    /// - Note: This method only initiates the session; actual connection status
     ///         is reported through session manager listener callbacks
+    ///
+    /// The index is bounds-checked against `GCKDiscoveryManager.deviceCount`
+    /// before accessing the underlying device. `GCKDiscoveryManager.device(at:)`
+    /// is backed by an `NSArray` and throws `NSRangeException` for out-of-bounds
+    /// access, which crashes the process (Swift cannot catch Obj-C exceptions).
+    /// The index comes from the Dart side, which holds a snapshot of the device
+    /// list received via `onDevicesChanged`; between that snapshot and this
+    /// call a device may disappear from the live discovery list (flaky
+    /// receivers, network hiccups), making the snapshot index stale.
     private func startSessionWithDevice(deviceIndex : Int ) -> Bool {
-        
+        let deviceCount = discoveryManager.deviceCount
+        guard deviceIndex >= 0, UInt(deviceIndex) < deviceCount else {
+            print("[GoogleCast] startSessionWithDevice: index \(deviceIndex) is out of bounds (deviceCount=\(deviceCount)); the Dart-side snapshot is stale")
+            return false
+        }
         let device = discoveryManager.device(at: UInt(deviceIndex))
         return sessionManager.startSession(with: device)
     }

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/SessionManagerMethodChannel.swift
@@ -464,36 +464,50 @@ public class FGCSessionManagerMethodChannel : UIResponder, FlutterPlugin, GCKSes
     
     /// Forcefully resets a stuck session.
     ///
-    /// 1. Removes the session manager listener so `endSessionAndStopCasting`
-    ///    does not generate spurious callbacks on the Flutter side.
-    /// 2. Cleans up the media client (listener, position timer, queue).
-    /// 3. Force-ends any existing session via `endSessionAndStopCasting(true)`.
-    /// 4. Resets the dedup state (`_lastEmittedConnectionState`).
-    /// 5. Re-adds the session manager listener.
-    /// 6. Emits a `null` session to Flutter.
+    /// 1. Early-returns when there is no current session — nothing to reset.
+    /// 2. Removes the session manager listener so `endSessionAndStopCasting`
+    ///    does not generate spurious `willEnd`/`didEnd` callbacks on the
+    ///    Flutter side.
+    /// 3. Cleans up the media client (listener, position timer, queue).
+    /// 4. Force-ends the existing session via `endSessionAndStopCasting(true)`.
+    /// 5. Resets the dedup state (`_lastEmittedConnectionState`) so the next
+    ///    session is tracked from scratch.
+    /// 6. Explicitly emits a `null` session to Flutter. `onSessionChanged(nil)`
+    ///    is intentionally bypassed here because its dedup check (`nil == nil`)
+    ///    would silently drop the emission.
+    /// 7. Re-adds the session manager listener.
     ///
     /// - Parameter result: Flutter result callback
     private func resetSession(_ result: FlutterResult) {
         print("[GoogleCast] resetSession: force-ending session and cleaning up all state")
-        
+
+        // Nothing to reset — avoid unnecessary listener churn and media cleanup
+        guard sessionManager.currentSession != nil else {
+            result(true)
+            return
+        }
+
         // Remove listener so endSessionAndStopCasting does not fire
         // willEnd/didEnd and produce stale events on the Flutter side
         sessionManager.remove(self)
-        
+
         // Clean up media client
         RemoteMediaClienteMethodChannel.instance.cleanUp()
-        
-        // Force-end any existing session
-        if sessionManager.currentSession != nil {
-            sessionManager.endSessionAndStopCasting(true)
-        }
-        
+
+        // Force-end the existing session
+        sessionManager.endSessionAndStopCasting(true)
+
         // Reset dedup state — the next session will be tracked from scratch
         _lastEmittedConnectionState = nil
-        
+
+        // Explicitly notify Flutter that the session is gone. We bypass
+        // onSessionChanged(nil) because its dedup check would silently skip
+        // the emission when no previous null has been tracked.
+        channel?.invokeMethod("onCurrentSessionChanged", arguments: nil)
+
         // Re-add listener
         sessionManager.add(self)
-        
+
         result(true)
     }
     

--- a/lib/_session_manager/android_cast_session_manager.dart
+++ b/lib/_session_manager/android_cast_session_manager.dart
@@ -103,4 +103,11 @@ class GoogleCastSessionManagerAndroidMethodChannel
   void setDeviceVolume(double value) {
     _channel.invokeMethod('setStreamVolume', value);
   }
+
+  @override
+  Future<bool> resetSession() async {
+    // Stale sessions are not observed on Android;
+    // delegate to the standard endSessionAndStopCasting
+    return endSessionAndStopCasting();
+  }
 }

--- a/lib/_session_manager/cast_session_manager_platform.dart
+++ b/lib/_session_manager/cast_session_manager_platform.dart
@@ -113,4 +113,11 @@ abstract class GoogleCastSessionManagerPlatformInterface
 
   /// Sets the device volume.
   void setDeviceVolume(double value);
+
+  /// Forcefully resets a stuck session.
+  ///
+  /// Removes the session manager listener, cleans up the media client,
+  /// force-ends any existing session, resets dedup state, re-adds the
+  /// listener and emits a null session to Flutter.
+  Future<bool> resetSession();
 }

--- a/lib/_session_manager/cast_session_manager_platform.dart
+++ b/lib/_session_manager/cast_session_manager_platform.dart
@@ -116,8 +116,14 @@ abstract class GoogleCastSessionManagerPlatformInterface
 
   /// Forcefully resets a stuck session.
   ///
-  /// Removes the session manager listener, cleans up the media client,
-  /// force-ends any existing session, resets dedup state, re-adds the
-  /// listener and emits a null session to Flutter.
+  /// On iOS this performs a full teardown: it removes the session manager
+  /// listener, cleans up the remote media client (listener, position timer,
+  /// queue), force-ends the current session, resets internal dedup state,
+  /// re-adds the listener, and emits a `null` session to Flutter so that
+  /// [currentSessionStream], [currentSession] and [connectionState] are
+  /// cleared.
+  ///
+  /// On Android this delegates to [endSessionAndStopCasting] because
+  /// stale-session issues are not observed on that platform.
   Future<bool> resetSession();
 }

--- a/lib/_session_manager/ios_cast_session_manager.dart
+++ b/lib/_session_manager/ios_cast_session_manager.dart
@@ -97,4 +97,9 @@ class GoogleCastSessionManagerIOSMethodChannel
   void setDeviceVolume(double value) {
     _channel.invokeMethod('setDeviceVolume', value);
   }
+
+  @override
+  Future<bool> resetSession() async {
+    return await _channel.invokeMethod('resetSession');
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chrome_cast
 description: A Flutter plugin for integrating Google Cast devices. Discover, connect, and control media playback on Chromecast and Cast-enabled devices.
-version: 1.4.5
+version: 1.4.6
 repository: https://github.com/felnanuke2/flutter_google_cast
 license: BSD-3-Clause
 

--- a/test/_session_manager/android_cast_session_manager_test.dart
+++ b/test/_session_manager/android_cast_session_manager_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_chrome_cast/_session_manager/android_cast_session_manager.dart';
+import 'package:flutter_chrome_cast/_session_manager/cast_session_manager_platform.dart';
+
+void main() {
+  group('GoogleCastSessionManagerAndroidMethodChannel', () {
+    late GoogleCastSessionManagerAndroidMethodChannel manager;
+    late List<MethodCall> methodCalls;
+    const channel =
+        MethodChannel('com.felnanuke.google_cast.session_manager');
+
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      methodCalls = [];
+      manager = GoogleCastSessionManagerAndroidMethodChannel();
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    test('should implement GoogleCastSessionManagerPlatformInterface', () {
+      expect(manager, isA<GoogleCastSessionManagerPlatformInterface>());
+    });
+
+    test(
+        'resetSession delegates to endSessionAndStopCasting on Android '
+        'because stale sessions are not observed on that platform', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        methodCalls.add(call);
+        return true;
+      });
+
+      final result = await manager.resetSession();
+
+      expect(result, isTrue);
+      expect(methodCalls, hasLength(1));
+      // Must NOT invoke a native "resetSession" on Android — delegation only.
+      expect(methodCalls.first.method, equals('endSessionAndStopCasting'));
+    });
+
+    test('resetSession propagates false from endSessionAndStopCasting',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        methodCalls.add(call);
+        return false;
+      });
+
+      final result = await manager.resetSession();
+
+      expect(result, isFalse);
+      expect(methodCalls.single.method, equals('endSessionAndStopCasting'));
+    });
+  });
+}

--- a/test/_session_manager/android_cast_session_manager_test.dart
+++ b/test/_session_manager/android_cast_session_manager_test.dart
@@ -8,8 +8,7 @@ void main() {
   group('GoogleCastSessionManagerAndroidMethodChannel', () {
     late GoogleCastSessionManagerAndroidMethodChannel manager;
     late List<MethodCall> methodCalls;
-    const channel =
-        MethodChannel('com.felnanuke.google_cast.session_manager');
+    const channel = MethodChannel('com.felnanuke.google_cast.session_manager');
 
     setUp(() {
       TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/_session_manager/android_cast_session_manager_test.dart
+++ b/test/_session_manager/android_cast_session_manager_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_chrome_cast/_session_manager/android_cast_session_manager.dart';
 import 'package:flutter_chrome_cast/_session_manager/cast_session_manager_platform.dart';
+import 'package:flutter_chrome_cast/models/android/cast_device.dart';
 
 void main() {
   group('GoogleCastSessionManagerAndroidMethodChannel', () {
@@ -23,6 +24,59 @@ void main() {
 
     test('should implement GoogleCastSessionManagerPlatformInterface', () {
       expect(manager, isA<GoogleCastSessionManagerPlatformInterface>());
+    });
+
+    test(
+        'startSessionWithDevice invokes native "startSessionWithDeviceId" '
+        'with the Android device ID', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        methodCalls.add(call);
+        return true;
+      });
+
+      final device = GoogleCastAndroidDevice(
+        deviceID: 'device-1',
+        friendlyName: 'Living Room TV',
+        modelName: 'Chromecast',
+        statusText: null,
+        deviceVersion: '5',
+        isOnLocalNetwork: true,
+        category: 'cast',
+        uniqueID: 'device-1',
+      );
+
+      final result = await manager.startSessionWithDevice(device);
+
+      expect(result, isTrue);
+      expect(methodCalls, hasLength(1));
+      expect(methodCalls.first.method, equals('startSessionWithDeviceId'));
+      expect(methodCalls.first.arguments, equals('device-1'));
+    });
+
+    test('startSessionWithDevice propagates false from the native side',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        methodCalls.add(call);
+        return false;
+      });
+
+      final device = GoogleCastAndroidDevice(
+        deviceID: 'device-1',
+        friendlyName: 'Living Room TV',
+        modelName: 'Chromecast',
+        statusText: null,
+        deviceVersion: '5',
+        isOnLocalNetwork: true,
+        category: 'cast',
+        uniqueID: 'device-1',
+      );
+
+      final result = await manager.startSessionWithDevice(device);
+
+      expect(result, isFalse);
+      expect(methodCalls.single.method, equals('startSessionWithDeviceId'));
     });
 
     test(

--- a/test/_session_manager/ios_cast_session_manager_test.dart
+++ b/test/_session_manager/ios_cast_session_manager_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_chrome_cast/_session_manager/ios_cast_session_manager.dart';
 import 'package:flutter_chrome_cast/_session_manager/cast_session_manager_platform.dart';
+import 'package:flutter_chrome_cast/models/ios/ios_cast_device.dart';
 
 void main() {
   group('GoogleCastSessionManagerIOSMethodChannel', () {
@@ -22,6 +23,61 @@ void main() {
 
     test('should implement GoogleCastSessionManagerPlatformInterface', () {
       expect(manager, isA<GoogleCastSessionManagerPlatformInterface>());
+    });
+
+    test(
+        'startSessionWithDevice invokes native "startSessionWithDevice" '
+        'with the iOS discovery index', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        methodCalls.add(call);
+        return true;
+      });
+
+      final device = GoogleCastIosDevice(
+        deviceID: 'device-1',
+        friendlyName: 'Living Room TV',
+        modelName: 'AirReceiver',
+        statusText: 'Ready',
+        deviceVersion: '5',
+        isOnLocalNetwork: true,
+        category: 'com.google.cast.CastDevice',
+        uniqueID: 'com.google.cast.CastDevice:device-1',
+        index: 1,
+      );
+
+      final result = await manager.startSessionWithDevice(device);
+
+      expect(result, isTrue);
+      expect(methodCalls, hasLength(1));
+      expect(methodCalls.first.method, equals('startSessionWithDevice'));
+      expect(methodCalls.first.arguments, equals(1));
+    });
+
+    test('startSessionWithDevice propagates false from the native side',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        methodCalls.add(call);
+        return false;
+      });
+
+      final device = GoogleCastIosDevice(
+        deviceID: 'device-1',
+        friendlyName: 'Living Room TV',
+        modelName: 'AirReceiver',
+        statusText: 'Ready',
+        deviceVersion: '5',
+        isOnLocalNetwork: true,
+        category: 'com.google.cast.CastDevice',
+        uniqueID: 'com.google.cast.CastDevice:device-1',
+        index: 1,
+      );
+
+      final result = await manager.startSessionWithDevice(device);
+
+      expect(result, isFalse);
+      expect(methodCalls.single.method, equals('startSessionWithDevice'));
     });
 
     test('resetSession invokes native "resetSession" and returns its result',

--- a/test/_session_manager/ios_cast_session_manager_test.dart
+++ b/test/_session_manager/ios_cast_session_manager_test.dart
@@ -96,8 +96,7 @@ void main() {
       expect(methodCalls.first.arguments, isNull);
     });
 
-    test('resetSession propagates false returned by the native side',
-        () async {
+    test('resetSession propagates false returned by the native side', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall call) async {
         methodCalls.add(call);

--- a/test/_session_manager/ios_cast_session_manager_test.dart
+++ b/test/_session_manager/ios_cast_session_manager_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_chrome_cast/_session_manager/ios_cast_session_manager.dart';
+import 'package:flutter_chrome_cast/_session_manager/cast_session_manager_platform.dart';
+
+void main() {
+  group('GoogleCastSessionManagerIOSMethodChannel', () {
+    late GoogleCastSessionManagerIOSMethodChannel manager;
+    late List<MethodCall> methodCalls;
+    const channel = MethodChannel('google_cast.session_manager');
+
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      methodCalls = [];
+      manager = GoogleCastSessionManagerIOSMethodChannel();
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    test('should implement GoogleCastSessionManagerPlatformInterface', () {
+      expect(manager, isA<GoogleCastSessionManagerPlatformInterface>());
+    });
+
+    test('resetSession invokes native "resetSession" and returns its result',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        methodCalls.add(call);
+        return true;
+      });
+
+      final result = await manager.resetSession();
+
+      expect(result, isTrue);
+      expect(methodCalls, hasLength(1));
+      expect(methodCalls.first.method, equals('resetSession'));
+      expect(methodCalls.first.arguments, isNull);
+    });
+
+    test('resetSession propagates false returned by the native side',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        methodCalls.add(call);
+        return false;
+      });
+
+      final result = await manager.resetSession();
+
+      expect(result, isFalse);
+      expect(methodCalls.single.method, equals('resetSession'));
+    });
+  });
+}


### PR DESCRIPTION
## Pull Request: Reset Connection (v1.4.6)

### Problem

On iOS, after an unexpected Chromecast disconnection (e.g. device going out of range, network interruption, or receiver restart), reconnecting to the same Cast device without restarting the app was unreliable. The SDK would leave a torn-down session in a limbo state — no longer considered connected, yet still holding internal resources — which silently blocked any subsequent connection attempt. The only reliable workaround was a full app restart.

### Summary

Introduces a new `resetSession()` API to forcefully clear all session and media client state on iOS, enabling a clean reconnect after a stuck or interrupted Cast session. Android delegates to the existing `endSessionAndStopCasting()` since stale-session issues are not observed on that platform.

---

### Changes

#### Dart — Platform Interface
- **`cast_session_manager_platform.dart`**: Added `resetSession()` as an abstract method on `GoogleCastSessionManagerPlatformInterface`. Documented as a force-reset that removes the session listener, cleans up the media client, ends the current session, resets dedup state, re-adds the listener, and emits a `null` session to Flutter.

#### Dart — iOS Channel
- **`ios_cast_session_manager.dart`**: Implemented `resetSession()` by invoking the `'resetSession'` method channel call on the native side.

#### Dart — Android Channel
- **`android_cast_session_manager.dart`**: Implemented `resetSession()` as a thin wrapper that delegates to `endSessionAndStopCasting()`, since Android does not exhibit stale-session problems.

#### Swift — Session Manager
- **`SessionManagerMethodChannel.swift`**: Added a `'resetSession'` case to the method call handler and implemented the private `resetSession(_ result:)` method. The method:
  1. Temporarily removes the session manager listener to suppress spurious `willEnd`/`didEnd` callbacks on the Flutter side.
  2. Calls `RemoteMediaClienteMethodChannel.instance.cleanUp()` to tear down media client state.
  3. Force-ends the current session via `endSessionAndStopCasting(true)` if a session exists.
  4. Resets `_lastEmittedConnectionState` so the next session is tracked from scratch.
  5. Re-adds the session manager listener.
  6. Returns `true` to Flutter via the result callback.

#### Swift — Remote Media Client
- **`RemoteMediaClienteMethodChannel.swift`**: Added a public `cleanUp()` method that removes the media client listener, invalidates and clears the position timer, and empties both `queueItems` and `queueOrder`. This method is called by the session reset logic to ensure no stale media state lingers after a forced disconnect.

#### Package
- **`pubspec.yaml`**: Version bumped from `1.4.5` to `1.4.6`.
- **`CHANGELOG.md`**: Added release notes for `1.4.6` describing the new feature and platform-specific behaviour.
