### PR TITLE
iOS content id fix

### DIFF
--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaInfoExtensions.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaInfoExtensions.swift
@@ -91,14 +91,16 @@ extension GCKMediaInformation{
     
     func toMap() -> Dictionary<String, Any> {
         var dict = Dictionary<String, Any>()
-        // GCKMediaInformation may return an empty/nil contentID when media was
-        // loaded via contentURL (the iOS SDK does not derive contentID from the
-        // URL automatically). Fall back to contentURL so the Dart layer always
-        // receives a non-empty identifier, matching Android behaviour.
+        // Only return the receiver-reported contentID here. The plugin layer
+        // (RemoteMediaClienteMethodChannel) is responsible for substituting
+        // the contentID that the Flutter side originally passed when loading
+        // media, because the Default Media Receiver does not always echo it
+        // back in the first media status update. A contentURL fallback is
+        // applied by the plugin layer only when no contentID is available at
+        // all. This keeps iOS behaviour consistent with Android, where the
+        // originally provided contentID is always delivered first.
         if let contentID = self.contentID, !contentID.isEmpty {
             dict["contentID"] = contentID
-        } else {
-            dict["contentID"] = self.contentURL?.absoluteString ?? ""
         }
         dict["contentType"] = self.contentType
         dict["streamType"] = self.streamType.rawValue

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaInfoExtensions.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaInfoExtensions.swift
@@ -27,6 +27,9 @@ extension GCKMediaInformation{
         
         let builder =  GCKMediaInformationBuilder.init(contentURL: contentUrl)
         builder.streamType = streamType
+        if let contentID = arguments["contentID"] as? String, !contentID.isEmpty {
+            builder.contentID = contentID
+        }
         if let contentType = arguments["contentType"] as? String {
              builder.contentType = contentType
         }
@@ -88,7 +91,15 @@ extension GCKMediaInformation{
     
     func toMap() -> Dictionary<String, Any> {
         var dict = Dictionary<String, Any>()
-        dict["contentID"] = self.contentID
+        // GCKMediaInformation may return an empty/nil contentID when media was
+        // loaded via contentURL (the iOS SDK does not derive contentID from the
+        // URL automatically). Fall back to contentURL so the Dart layer always
+        // receives a non-empty identifier, matching Android behaviour.
+        if let contentID = self.contentID, !contentID.isEmpty {
+            dict["contentID"] = contentID
+        } else {
+            dict["contentID"] = self.contentURL?.absoluteString ?? ""
+        }
         dict["contentType"] = self.contentType
         dict["streamType"] = self.streamType.rawValue
         dict["contentURL"] = self.contentURL?.absoluteString

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/RemoteMediaClienteMethodChannel.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/RemoteMediaClienteMethodChannel.swift
@@ -70,6 +70,17 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
     /// Dictionary storing queue items by their ID
     /// Maps queue item IDs to their corresponding GCKMediaQueueItem objects
     private var queueItems  : Dictionary<UInt, GCKMediaQueueItem> = [:]
+
+    /// The last `contentID` that the Flutter side passed when loading media.
+    ///
+    /// The Google Cast Default Media Receiver does not always echo the
+    /// `contentID` we sent back in the first `mediaStatus` update — in that
+    /// case `GCKMediaInformation.contentID` is nil/empty. To match Android
+    /// behaviour (where the originally provided `contentID` is delivered from
+    /// the very first update), we cache the value sent from Flutter and
+    /// substitute it into the media status map whenever the receiver reports
+    /// an empty `contentID`.
+    private var lastLoadedContentID: String?
     
     /// Computed property returning queue items in proper order
     /// - Returns: Array of queue items sorted according to queueOrder
@@ -234,6 +245,15 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
             return
             
         }
+
+        // Cache the contentID that Flutter passed so we can inject it into
+        // subsequent media status updates where the receiver reports no
+        // contentID back (see `applyContentIDFallback`).
+        if let contentID = arguments["contentID"] as? String, !contentID.isEmpty {
+            self.lastLoadedContentID = contentID
+        } else {
+            self.lastLoadedContentID = nil
+        }
         
         print("[GoogleCast] loadMedia() mediaInfo created - contentID: \(mediaInfo.contentID ?? "nil"), contentType: \(mediaInfo.contentType ?? "nil"), streamType: \(mediaInfo.streamType.rawValue)")
         
@@ -339,11 +359,38 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
         print("[GoogleCast] didUpdate mediaStatus - playerState: \(mediaStatus?.playerState.rawValue ?? -1), idleReason: \(mediaStatus?.idleReason.rawValue ?? -1)")
         print("[GoogleCast] mediaStatus contentID: \(mediaStatus?.mediaInformation?.contentID ?? "nil")")
         startListenPlayerPosition()
-     let data = mediaStatus?.toMap()
-       
+        var data = mediaStatus?.toMap()
+        applyContentIDFallback(&data)
+
         channel?.invokeMethod("onUpdateMediaStatus", arguments:data)
         if client.mediaStatus?.idleReason == .finished {
          onSessionEnd()
+        }
+    }
+
+    /// Ensures the media status map forwarded to Flutter always contains a
+    /// usable `contentID` inside `mediaInformation`.
+    ///
+    /// Priority:
+    ///   1. `contentID` already populated by the receiver (kept as-is).
+    ///   2. The `contentID` originally passed from Flutter in `loadMedia`
+    ///      (cached in `lastLoadedContentID`).
+    ///   3. `contentURL` as a last-resort fallback.
+    private func applyContentIDFallback(_ data: inout Dictionary<String, Any>?) {
+        guard var status = data,
+              var mediaInformation = status["mediaInformation"] as? Dictionary<String, Any> else {
+            return
+        }
+
+        let existing = mediaInformation["contentID"] as? String
+        if existing == nil || existing?.isEmpty == true {
+            if let cached = lastLoadedContentID, !cached.isEmpty {
+                mediaInformation["contentID"] = cached
+            } else if let contentURL = mediaInformation["contentURL"] as? String, !contentURL.isEmpty {
+                mediaInformation["contentID"] = contentURL
+            }
+            status["mediaInformation"] = mediaInformation
+            data = status
         }
     }
     
@@ -413,6 +460,7 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
     public func onSessionEnd(){
         queueItems.removeAll()
         queueOrder.removeAll()
+        lastLoadedContentID = nil
         updateQueueItems()
     }
     


### PR DESCRIPTION
### Summary

This PR fixes an iOS-specific issue where `contentID` was missing in media status updates right after `loadMedia`.

In the affected flow, Flutter sent a valid `contentID`, but on iOS the Default Media Receiver could return media status data with an empty `contentID` string. As a result, the Flutter side did not receive the original identifier in the first updates, which made iOS behavior inconsistent with Android.

### What changed

On iOS, the plugin now caches the `contentID` provided from Flutter when media is loaded and uses it as a fallback when forwarding media status updates back to Flutter.

Fallback behavior is now:

1. Use the `contentID` returned by the receiver if it is present.
2. If iOS returns an empty or missing `contentID`, use the original `contentID` passed from Flutter.
3. If neither is available, fall back to `contentURL`.

The media info serialization logic was also clarified so the raw receiver payload stays separate from the compatibility fallback applied before the status is sent to Flutter.