### PR TITLE
iOS position fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.7 - iOS Stale Position After Content Switch
+### 🐛 Bug Fixes
+- **iOS stale playback position after `loadMedia`**: Fixed `playerPosition` briefly showing the previous content's offset right after switching media. Position ticks are now suppressed until the SDK reports a new `mediaSessionID` and `approximateStreamPosition()` converges to the requested start time (±5 s tolerance), with a 10 s safety timeout.
+
+### 🔧 Notes
+- No public API changes.
+
 ## 1.4.6 - iOS Force Session Reset
 ### New Features
 - Added `resetSession()` to force a clean iOS Cast session reset after interrupted or stuck connections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.4.7 - iOS Stale Position After Content Switch
+## 1.4.8 - iOS Stale Position After Content Switch
 ### 🐛 Bug Fixes
 - **iOS stale playback position after `loadMedia`**: Fixed `playerPosition` briefly showing the previous content's offset right after switching media. Position ticks are now suppressed until the SDK reports a new `mediaSessionID` and `approximateStreamPosition()` converges to the requested start time (±5 s tolerance), with a 10 s safety timeout.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.6"
+    version: "1.4.7"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/ios/flutter_chrome_cast.podspec
+++ b/ios/flutter_chrome_cast.podspec
@@ -7,7 +7,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_chrome_cast'
-  s.version          = '1.4.1'
+  s.version          = '1.4.7'
   s.summary          = 'A comprehensive Flutter plugin for Google Cast SDK integration on iOS and Android.'
   s.description      = <<-DESC
 FlutterGoogleCast provides seamless integration with the Google Cast SDK for Flutter applications.

--- a/ios/flutter_chrome_cast.podspec
+++ b/ios/flutter_chrome_cast.podspec
@@ -7,7 +7,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_chrome_cast'
-  s.version          = '1.4.7'
+  s.version          = '1.4.8'
   s.summary          = 'A comprehensive Flutter plugin for Google Cast SDK integration on iOS and Android.'
   s.description      = <<-DESC
 FlutterGoogleCast provides seamless integration with the Google Cast SDK for Flutter applications.

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/RemoteMediaClienteMethodChannel.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/RemoteMediaClienteMethodChannel.swift
@@ -82,56 +82,6 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
     /// an empty `contentID`.
     private var lastLoadedContentID: String?
 
-    // MARK: - Post-load position guard
-    //
-    // After `loadMedia(with:)`, `GCKRemoteMediaClient.approximateStreamPosition()`
-    // keeps returning a stale extrapolation based on the *previous* content's
-    // last known `mediaStatus.streamPosition` until the SDK actually applies
-    // the first `mediaStatus` of the new media session to its internal
-    // baseline. Empirically this lag is ~0.3–1.5s on iOS even though both
-    // `mediaSessionID` and `contentID` are already reported as new in the
-    // listener callback. Android does not suffer from this because there we
-    // use `addProgressListener(_, 500)` which is push-based from the SDK —
-    // the SDK only notifies once it has applied the new baseline.
-    //
-    // To match Android behaviour we filter the polled value here: while a
-    // load is pending we know the expected start position (the `startTime`
-    // we just asked for), and any value that is far from it must still be
-    // stale extrapolation of the previous content. We drop such ticks until
-    // the value converges to the expected start position, then release the
-    // guard. A safety timeout protects against edge cases (e.g. receiver
-    // started playback far away from the requested position) so the guard
-    // is not stuck forever.
-
-    /// Expected stream position (seconds) of the media that is currently
-    /// being loaded. `nil` when no load is in flight.
-    private var pendingLoadExpectedPosition: TimeInterval?
-
-    /// `mediaSessionID` observed at the moment the guard was armed. The guard
-    /// stays armed until the SDK reports a *different* session ID — this
-    /// protects against the case when the previous content's stale position
-    /// happens to be within `pendingLoadGuardTolerance` of the requested
-    /// `startTime` (e.g. user reloads at roughly the same offset), which
-    /// otherwise would let a stale tick through purely by numerical
-    /// coincidence.
-    private var pendingLoadPreviousMediaSessionID: Int?
-
-    /// Safety work item that releases `pendingLoadExpectedPosition` after
-    /// `pendingLoadGuardTimeout` if convergence never happens.
-    private var pendingLoadGuardWorkItem: DispatchWorkItem?
-
-    /// Maximum time the guard stays armed. After this it is released even
-    /// if `approximateStreamPosition()` never converged to the expected
-    /// start position — we'd rather emit a possibly-imprecise value than
-    /// hang the position stream indefinitely.
-    private let pendingLoadGuardTimeout: TimeInterval = 10
-
-    /// Tolerance (seconds) within which `approximateStreamPosition()` is
-    /// considered to have caught up with the new media session. Receivers
-    /// may start playback slightly off the requested `startTime` due to
-    /// keyframe alignment / buffering, so a few seconds of slack is fine.
-    private let pendingLoadGuardTolerance: TimeInterval = 5
-
     /// Computed property returning queue items in proper order
     /// - Returns: Array of queue items sorted according to queueOrder
     private var orderedQueueItems : Array<GCKMediaQueueItem> {
@@ -331,27 +281,8 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
             requestDataBuilder.customData = customData as NSObject
         }
         let requestData = requestDataBuilder.build()
-        print("[GoogleCast] loadMedia() options: autoplay=\(String(describing: requestData.autoplay)), playPosition=\(requestData.startTime)")
-        print("[GoogleCast] loadMedia() remoteMediaClient: \(String(describing: currentRemoteMediaCliente))")
-
-        // Capture the *current* media session ID before dispatching the load
-        // so the guard can detect when the SDK has switched to the new media
-        // session (see `pendingLoadPreviousMediaSessionID`).
-        let previousSessionID = currentRemoteMediaCliente?.mediaStatus?.mediaSessionID
 
         let request = currentRemoteMediaCliente?.loadMedia(with: requestData)
-        print("[GoogleCast] loadMedia() request: \(String(describing: request))")
-
-        // Only arm the position guard once we know the load was actually
-        // accepted by the SDK. Arming unconditionally would suppress valid
-        // ticks for up to `pendingLoadGuardTimeout` seconds whenever there is
-        // no current remote media client / the request could not be created.
-        if request != nil {
-            armPendingLoadGuard(
-                expectedPosition: requestData.startTime,
-                previousMediaSessionID: previousSessionID
-            )
-        }
 
         result(request?.toMap())
         
@@ -529,7 +460,6 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
         queueItems.removeAll()
         queueOrder.removeAll()
         lastLoadedContentID = nil
-        releasePendingLoadGuard()
         updateQueueItems()
     }
     
@@ -540,7 +470,6 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
         currentRemoteMediaCliente?.remove(self)
         positionTimer?.invalidate()
         positionTimer = nil
-        releasePendingLoadGuard()
         queueItems.removeAll()
         queueOrder.removeAll()
     }
@@ -557,63 +486,8 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
         self.positionTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true){ [weak self] _ in
             guard let self = self else { return }
             let position = self.currentRemoteMediaCliente?.approximateStreamPosition() ?? 0
-
-            // Post-load guard: while a media load is in flight,
-            // `approximateStreamPosition()` extrapolates from the previous
-            // content's baseline and would leak its stale position into
-            // the Flutter stream. Drop ticks until BOTH:
-            //   1. the SDK has switched to a new `mediaSessionID` (so we
-            //      know the new media status has been applied — guards
-            //      against stale values that happen to be numerically
-            //      close to the requested `startTime`);
-            //   2. `approximateStreamPosition()` has converged to the
-            //      requested `startTime` within tolerance (the SDK reports
-            //      the new session id slightly before the position
-            //      baseline catches up).
-            if let expected = self.pendingLoadExpectedPosition {
-                let currentSessionID = self.currentRemoteMediaCliente?.mediaStatus?.mediaSessionID
-                let sessionChanged = currentSessionID != nil
-                    && currentSessionID != self.pendingLoadPreviousMediaSessionID
-                if !sessionChanged || abs(position - expected) > self.pendingLoadGuardTolerance {
-                    return
-                }
-                self.releasePendingLoadGuard()
-            }
-
             self.channel?.invokeMethod("onUpdatePlayerPosition", arguments: Int(position))
         }
     }
 
-    /// Arms the post-load position guard with the expected start position
-    /// of the media being loaded and the `mediaSessionID` observed right
-    /// before the load was dispatched. Also schedules the safety timeout
-    /// that releases the guard unconditionally after
-    /// [pendingLoadGuardTimeout] seconds.
-    private func armPendingLoadGuard(
-        expectedPosition: TimeInterval,
-        previousMediaSessionID: Int?
-    ) {
-        self.pendingLoadExpectedPosition = expectedPosition
-        self.pendingLoadPreviousMediaSessionID = previousMediaSessionID
-        self.pendingLoadGuardWorkItem?.cancel()
-        let workItem = DispatchWorkItem { [weak self] in
-            self?.pendingLoadExpectedPosition = nil
-            self?.pendingLoadPreviousMediaSessionID = nil
-            self?.pendingLoadGuardWorkItem = nil
-        }
-        self.pendingLoadGuardWorkItem = workItem
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + pendingLoadGuardTimeout,
-            execute: workItem
-        )
-    }
-
-    /// Releases the post-load position guard and cancels the safety timer.
-    private func releasePendingLoadGuard() {
-        self.pendingLoadExpectedPosition = nil
-        self.pendingLoadPreviousMediaSessionID = nil
-        self.pendingLoadGuardWorkItem?.cancel()
-        self.pendingLoadGuardWorkItem = nil
-    }
-   
 }

--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/RemoteMediaClienteMethodChannel.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/RemoteMediaClienteMethodChannel.swift
@@ -81,7 +81,57 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
     /// substitute it into the media status map whenever the receiver reports
     /// an empty `contentID`.
     private var lastLoadedContentID: String?
-    
+
+    // MARK: - Post-load position guard
+    //
+    // After `loadMedia(with:)`, `GCKRemoteMediaClient.approximateStreamPosition()`
+    // keeps returning a stale extrapolation based on the *previous* content's
+    // last known `mediaStatus.streamPosition` until the SDK actually applies
+    // the first `mediaStatus` of the new media session to its internal
+    // baseline. Empirically this lag is ~0.3–1.5s on iOS even though both
+    // `mediaSessionID` and `contentID` are already reported as new in the
+    // listener callback. Android does not suffer from this because there we
+    // use `addProgressListener(_, 500)` which is push-based from the SDK —
+    // the SDK only notifies once it has applied the new baseline.
+    //
+    // To match Android behaviour we filter the polled value here: while a
+    // load is pending we know the expected start position (the `startTime`
+    // we just asked for), and any value that is far from it must still be
+    // stale extrapolation of the previous content. We drop such ticks until
+    // the value converges to the expected start position, then release the
+    // guard. A safety timeout protects against edge cases (e.g. receiver
+    // started playback far away from the requested position) so the guard
+    // is not stuck forever.
+
+    /// Expected stream position (seconds) of the media that is currently
+    /// being loaded. `nil` when no load is in flight.
+    private var pendingLoadExpectedPosition: TimeInterval?
+
+    /// `mediaSessionID` observed at the moment the guard was armed. The guard
+    /// stays armed until the SDK reports a *different* session ID — this
+    /// protects against the case when the previous content's stale position
+    /// happens to be within `pendingLoadGuardTolerance` of the requested
+    /// `startTime` (e.g. user reloads at roughly the same offset), which
+    /// otherwise would let a stale tick through purely by numerical
+    /// coincidence.
+    private var pendingLoadPreviousMediaSessionID: Int?
+
+    /// Safety work item that releases `pendingLoadExpectedPosition` after
+    /// `pendingLoadGuardTimeout` if convergence never happens.
+    private var pendingLoadGuardWorkItem: DispatchWorkItem?
+
+    /// Maximum time the guard stays armed. After this it is released even
+    /// if `approximateStreamPosition()` never converged to the expected
+    /// start position — we'd rather emit a possibly-imprecise value than
+    /// hang the position stream indefinitely.
+    private let pendingLoadGuardTimeout: TimeInterval = 10
+
+    /// Tolerance (seconds) within which `approximateStreamPosition()` is
+    /// considered to have caught up with the new media session. Receivers
+    /// may start playback slightly off the requested `startTime` due to
+    /// keyframe alignment / buffering, so a few seconds of slack is fine.
+    private let pendingLoadGuardTolerance: TimeInterval = 5
+
     /// Computed property returning queue items in proper order
     /// - Returns: Array of queue items sorted according to queueOrder
     private var orderedQueueItems : Array<GCKMediaQueueItem> {
@@ -283,8 +333,26 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
         let requestData = requestDataBuilder.build()
         print("[GoogleCast] loadMedia() options: autoplay=\(String(describing: requestData.autoplay)), playPosition=\(requestData.startTime)")
         print("[GoogleCast] loadMedia() remoteMediaClient: \(String(describing: currentRemoteMediaCliente))")
+
+        // Capture the *current* media session ID before dispatching the load
+        // so the guard can detect when the SDK has switched to the new media
+        // session (see `pendingLoadPreviousMediaSessionID`).
+        let previousSessionID = currentRemoteMediaCliente?.mediaStatus?.mediaSessionID
+
         let request = currentRemoteMediaCliente?.loadMedia(with: requestData)
         print("[GoogleCast] loadMedia() request: \(String(describing: request))")
+
+        // Only arm the position guard once we know the load was actually
+        // accepted by the SDK. Arming unconditionally would suppress valid
+        // ticks for up to `pendingLoadGuardTimeout` seconds whenever there is
+        // no current remote media client / the request could not be created.
+        if request != nil {
+            armPendingLoadGuard(
+                expectedPosition: requestData.startTime,
+                previousMediaSessionID: previousSessionID
+            )
+        }
+
         result(request?.toMap())
         
         
@@ -461,6 +529,7 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
         queueItems.removeAll()
         queueOrder.removeAll()
         lastLoadedContentID = nil
+        releasePendingLoadGuard()
         updateQueueItems()
     }
     
@@ -471,6 +540,7 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
         currentRemoteMediaCliente?.remove(self)
         positionTimer?.invalidate()
         positionTimer = nil
+        releasePendingLoadGuard()
         queueItems.removeAll()
         queueOrder.removeAll()
     }
@@ -484,11 +554,66 @@ class RemoteMediaClienteMethodChannel :UIResponder, FlutterPlugin, GCKRemoteMedi
         self.positionTimer?.invalidate()
         self.positionTimer = nil
         
-        self.positionTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true){_ in
-            self.channel?.invokeMethod("onUpdatePlayerPosition", arguments: Int(self.currentRemoteMediaCliente?.approximateStreamPosition() ?? 0))
+        self.positionTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true){ [weak self] _ in
+            guard let self = self else { return }
+            let position = self.currentRemoteMediaCliente?.approximateStreamPosition() ?? 0
 
-            
+            // Post-load guard: while a media load is in flight,
+            // `approximateStreamPosition()` extrapolates from the previous
+            // content's baseline and would leak its stale position into
+            // the Flutter stream. Drop ticks until BOTH:
+            //   1. the SDK has switched to a new `mediaSessionID` (so we
+            //      know the new media status has been applied — guards
+            //      against stale values that happen to be numerically
+            //      close to the requested `startTime`);
+            //   2. `approximateStreamPosition()` has converged to the
+            //      requested `startTime` within tolerance (the SDK reports
+            //      the new session id slightly before the position
+            //      baseline catches up).
+            if let expected = self.pendingLoadExpectedPosition {
+                let currentSessionID = self.currentRemoteMediaCliente?.mediaStatus?.mediaSessionID
+                let sessionChanged = currentSessionID != nil
+                    && currentSessionID != self.pendingLoadPreviousMediaSessionID
+                if !sessionChanged || abs(position - expected) > self.pendingLoadGuardTolerance {
+                    return
+                }
+                self.releasePendingLoadGuard()
+            }
+
+            self.channel?.invokeMethod("onUpdatePlayerPosition", arguments: Int(position))
         }
+    }
+
+    /// Arms the post-load position guard with the expected start position
+    /// of the media being loaded and the `mediaSessionID` observed right
+    /// before the load was dispatched. Also schedules the safety timeout
+    /// that releases the guard unconditionally after
+    /// [pendingLoadGuardTimeout] seconds.
+    private func armPendingLoadGuard(
+        expectedPosition: TimeInterval,
+        previousMediaSessionID: Int?
+    ) {
+        self.pendingLoadExpectedPosition = expectedPosition
+        self.pendingLoadPreviousMediaSessionID = previousMediaSessionID
+        self.pendingLoadGuardWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.pendingLoadExpectedPosition = nil
+            self?.pendingLoadPreviousMediaSessionID = nil
+            self?.pendingLoadGuardWorkItem = nil
+        }
+        self.pendingLoadGuardWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + pendingLoadGuardTimeout,
+            execute: workItem
+        )
+    }
+
+    /// Releases the post-load position guard and cancels the safety timer.
+    private func releasePendingLoadGuard() {
+        self.pendingLoadExpectedPosition = nil
+        self.pendingLoadPreviousMediaSessionID = nil
+        self.pendingLoadGuardWorkItem?.cancel()
+        self.pendingLoadGuardWorkItem = nil
     }
    
 }

--- a/lib/_remote_media_client/ios_remote_media_client_method_channel.dart
+++ b/lib/_remote_media_client/ios_remote_media_client_method_channel.dart
@@ -29,6 +29,25 @@ class GoogleCastRemoteMediaClientIOSMethodChannel
   final _playerPositionStreamController = BehaviorSubject<Duration>()
     ..add(Duration.zero);
 
+  // After `loadMedia`, the native `GCKRemoteMediaClient.approximateStreamPosition()`
+  // keeps returning the previous content's last known position until the SDK
+  // applies the new mediaStatus on the device. As a result, the first few
+  // `onUpdatePlayerPosition` ticks emitted by the iOS side leak stale values
+  // from the previous content (e.g. 0:01:10 right after loading a new content
+  // whose intended start is 0:02:07). We block such stale ticks at the Dart
+  // boundary until BOTH conditions are met:
+  //   1. The mediaSessionID has changed compared to the one observed at the
+  //      moment of `loadMedia` (the SDK applied the new stream).
+  //   2. The reported position has converged to the expected start position
+  //      within a small tolerance.
+  // A safety timeout releases the guard if convergence never happens (e.g.
+  // playback was stopped/seeked before reaching the expected position).
+  Duration? _pendingLoadExpectedPosition;
+  int? _pendingLoadPreviousMediaSessionId;
+  Timer? _pendingLoadGuardTimer;
+  static const _pendingLoadGuardTimeout = Duration(seconds: 10);
+  static const _pendingLoadGuardTolerance = Duration(seconds: 5);
+
   final _queueItemsStreamController =
       BehaviorSubject<List<GoogleCastQueueItem>>()..add([]);
 
@@ -76,6 +95,9 @@ class GoogleCastRemoteMediaClientIOSMethodChannel
     String? credentialsType,
     Map<String, dynamic>? customData,
   }) async {
+    // Arm the stale-position guard BEFORE invoking the platform channel so
+    // that any position tick emitted right after `loadMedia` is filtered out.
+    _armPendingLoadGuard(playPosition);
     _channel.invokeMethod(
         'loadMedia',
         mediaInfo.toMap()
@@ -152,7 +174,46 @@ class GoogleCastRemoteMediaClientIOSMethodChannel
 
   Future _onUpdatePlayerPosition(int seconds) async {
     final duration = Duration(seconds: seconds);
+    final expected = _pendingLoadExpectedPosition;
+    if (expected != null) {
+      final currentSessionId =
+          _mediaStatusStreamController.value?.mediaSessionID;
+      // `mediaSessionID` is non-null `int` (defaults to 0 when no status yet).
+      // Treat 0 and the previously observed id as "not changed yet".
+      final sessionChanged = currentSessionId != null &&
+          currentSessionId != 0 &&
+          currentSessionId != _pendingLoadPreviousMediaSessionId;
+      final converged =
+          (duration - expected).abs() <= _pendingLoadGuardTolerance;
+      if (!sessionChanged || !converged) {
+        debugPrint(
+            '[Flutter] onUpdatePlayerPosition blocked: pos=$duration expected=$expected sessionChanged=$sessionChanged');
+        return;
+      }
+      debugPrint(
+          '[Flutter] onUpdatePlayerPosition guard released at pos=$duration');
+      _releasePendingLoadGuard();
+    }
     _playerPositionStreamController.add(duration);
+  }
+
+  void _armPendingLoadGuard(Duration expectedPosition) {
+    _pendingLoadExpectedPosition = expectedPosition;
+    _pendingLoadPreviousMediaSessionId =
+        _mediaStatusStreamController.value?.mediaSessionID;
+    _pendingLoadGuardTimer?.cancel();
+    _pendingLoadGuardTimer = Timer(_pendingLoadGuardTimeout, () {
+      debugPrint(
+          '[Flutter] onUpdatePlayerPosition guard timed out, releasing');
+      _releasePendingLoadGuard();
+    });
+  }
+
+  void _releasePendingLoadGuard() {
+    _pendingLoadExpectedPosition = null;
+    _pendingLoadPreviousMediaSessionId = null;
+    _pendingLoadGuardTimer?.cancel();
+    _pendingLoadGuardTimer = null;
   }
 
   /// Recursively converts a `Map<Object?, Object?>` to `Map<String, dynamic>`.

--- a/lib/_remote_media_client/ios_remote_media_client_method_channel.dart
+++ b/lib/_remote_media_client/ios_remote_media_client_method_channel.dart
@@ -201,6 +201,13 @@ class GoogleCastRemoteMediaClientIOSMethodChannel
     _pendingLoadExpectedPosition = expectedPosition;
     _pendingLoadPreviousMediaSessionId =
         _mediaStatusStreamController.value?.mediaSessionID;
+    // Overwrite the BehaviorSubject's cached value so that any consumer that
+    // reads `playerPosition` synchronously (e.g. polls it via a periodic
+    // timer) sees the expected start of the new content instead of the
+    // previous content's last reported position. Without this, even though
+    // `onUpdatePlayerPosition` ticks are filtered, the stale cached value
+    // leaks into the app right after `loadMedia`.
+    _playerPositionStreamController.add(expectedPosition);
     _pendingLoadGuardTimer?.cancel();
     _pendingLoadGuardTimer = Timer(_pendingLoadGuardTimeout, () {
       debugPrint(

--- a/lib/_remote_media_client/ios_remote_media_client_method_channel.dart
+++ b/lib/_remote_media_client/ios_remote_media_client_method_channel.dart
@@ -186,12 +186,8 @@ class GoogleCastRemoteMediaClientIOSMethodChannel
       final converged =
           (duration - expected).abs() <= _pendingLoadGuardTolerance;
       if (!sessionChanged || !converged) {
-        debugPrint(
-            '[Flutter] onUpdatePlayerPosition blocked: pos=$duration expected=$expected sessionChanged=$sessionChanged');
         return;
       }
-      debugPrint(
-          '[Flutter] onUpdatePlayerPosition guard released at pos=$duration');
       _releasePendingLoadGuard();
     }
     _playerPositionStreamController.add(duration);
@@ -210,8 +206,6 @@ class GoogleCastRemoteMediaClientIOSMethodChannel
     _playerPositionStreamController.add(expectedPosition);
     _pendingLoadGuardTimer?.cancel();
     _pendingLoadGuardTimer = Timer(_pendingLoadGuardTimeout, () {
-      debugPrint(
-          '[Flutter] onUpdatePlayerPosition guard timed out, releasing');
       _releasePendingLoadGuard();
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chrome_cast
 description: A Flutter plugin for integrating Google Cast devices. Discover, connect, and control media playback on Chromecast and Cast-enabled devices.
-version: 1.4.6
+version: 1.4.6+1
 repository: https://github.com/felnanuke2/flutter_google_cast
 license: BSD-3-Clause
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chrome_cast
 description: A Flutter plugin for integrating Google Cast devices. Discover, connect, and control media playback on Chromecast and Cast-enabled devices.
-version: 1.4.6+2
+version: 1.4.6+1
 repository: https://github.com/felnanuke2/flutter_google_cast
 license: BSD-3-Clause
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chrome_cast
 description: A Flutter plugin for integrating Google Cast devices. Discover, connect, and control media playback on Chromecast and Cast-enabled devices.
-version: 1.4.6+1
+version: 1.4.7
 repository: https://github.com/felnanuke2/flutter_google_cast
 license: BSD-3-Clause
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chrome_cast
 description: A Flutter plugin for integrating Google Cast devices. Discover, connect, and control media playback on Chromecast and Cast-enabled devices.
-version: 1.4.6+1
+version: 1.4.6+2
 repository: https://github.com/felnanuke2/flutter_google_cast
 license: BSD-3-Clause
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chrome_cast
 description: A Flutter plugin for integrating Google Cast devices. Discover, connect, and control media playback on Chromecast and Cast-enabled devices.
-version: 1.4.7
+version: 1.4.8
 repository: https://github.com/felnanuke2/flutter_google_cast
 license: BSD-3-Clause
 


### PR DESCRIPTION
## Fix stale player position after loadMedia on iOS + memory leak in position timer

### Problem

After calling `loadMedia` with a custom `playPosition`, the iOS `GCKRemoteMediaClient`
continues returning the **previous stream's last known position** for a brief period
until the device applies the new `mediaStatus`. This caused the player-position stream
to briefly emit stale values from the previous content (e.g. `1:10` right after loading
new content intended to start at `2:07`).

Additionally, `startListenPlayerPosition()` in Swift was capturing `self` strongly inside
the `Timer` closure, preventing the channel object from being deallocated as long as the
timer was alive — a memory leak.

### Solution

**Dart (iOS method channel):**
- Introduced a *pending-load position guard* that arms itself (synchronously) before the
  `loadMedia` platform-channel call.
- While the guard is active, `onUpdatePlayerPosition` ticks are suppressed until **both**
  conditions are satisfied:
  1. The `mediaSessionID` reported by the SDK has changed (new session is active).
  2. The reported position has converged to the requested `playPosition` within ±5 s.
- A 10-second safety timeout automatically releases the guard if convergence never
  occurs (e.g. the user paused or seeked before reaching the start point).
- The `BehaviorSubject` cache is pre-seeded with `playPosition` on arm so that
  synchronous reads of `playerPosition` immediately reflect the new content.

**Swift:**
- Replaced strong `self` capture in the `Timer` closure with `[weak self]` + `guard let`
  to fix the memory leak in `startListenPlayerPosition()`.
- Removed leftover `print()` debug statements from `loadMedia()`.