### PR TITLE
fix(android): forward HLS segment format + stream duration to MediaInfo

### DIFF
--- a/android/src/main/kotlin/com/felnanuke/google_cast/extensions/MediaInfoExtensions.kt
+++ b/android/src/main/kotlin/com/felnanuke/google_cast/extensions/MediaInfoExtensions.kt
@@ -56,8 +56,53 @@ class GoogleCastMediaInfo {
                 builder.setCustomData(JSONObject(customData))
             }
 
+            // Stream duration: Flutter sends seconds, the SDK expects milliseconds.
+            (map["duration"] as? Number)?.let {
+                builder.setStreamDuration((it.toDouble() * 1000).toLong())
+            }
+
+            // HLS segment formats. Required for fragmented-MP4 HLS (e.g. PeerTube
+            // VOD) to play on the Default Media Receiver: without the hint the
+            // receiver cannot demux fMP4 segments and stays stuck in LOADING.
+            (map["hlsSegmentFormat"] as? String)?.let { name ->
+                hlsSegmentFormatFromName(name)?.let { builder.setHlsSegmentFormat(it) }
+            }
+            (map["hlsVideoSegmentFormat"] as? String)?.let { name ->
+                hlsVideoSegmentFormatFromName(name)?.let {
+                    builder.setHlsVideoSegmentFormat(it)
+                }
+            }
+
             return builder.build()
         }
+
+        /**
+         * Maps the Flutter `CastHlsSegmentFormat` enum name to the string the
+         * Cast SDK / receiver expects (`MediaInfo.Builder.setHlsSegmentFormat`
+         * takes a String in play-services-cast). Returns null for unknown /
+         * `none` so the field is simply left unset.
+         */
+        private fun hlsSegmentFormatFromName(name: String): String? = when (name) {
+            "aac" -> "aac"
+            "ac3" -> "ac3"
+            "mp3" -> "mp3"
+            "ts" -> "ts"
+            "tsAac" -> "ts_aac"
+            "eAc3" -> "e-ac3"
+            "fmp4" -> "fmp4"
+            else -> null
+        }
+
+        /**
+         * Maps the Flutter `HlsVideoSegmentFormat` enum name to the string the
+         * Cast SDK / receiver expects.
+         */
+        private fun hlsVideoSegmentFormatFromName(name: String): String? =
+            when (name) {
+                "mpeg2Ts" -> "mpeg2_ts"
+                "fmp4" -> "fmp4"
+                else -> null
+            }
     }
 }
 


### PR DESCRIPTION
## Problem

On Android, fragmented-MP4 HLS VOD streams (e.g. PeerTube) stay stuck in
`LOADING` on the Default Media Receiver and never start playing.

The Dart layer already serializes `hlsSegmentFormat`, `hlsVideoSegmentFormat`
and `duration` (`MediaInformation.toMap`), and **iOS already forwards them**
(`MediaInfoExtensions.swift`). But the Android `MediaInfoExtensions.kt` ignored
all three when building the native `MediaInfo`, so:

- The receiver never gets the segment-format hint and cannot demux fMP4
  segments → infinite `LOADING`.
- `streamDuration` was never set.

This was a silent Android↔iOS parity gap.

## Fix

`GoogleCastMediaInfo.fromMap` now reads and forwards the missing fields on the
`MediaInfo.Builder`:

- `duration` → `setStreamDuration` (Flutter sends **seconds**, the Android SDK
  expects **milliseconds**, so it's converted `* 1000`; iOS keeps seconds).
- `hlsSegmentFormat` → `setHlsSegmentFormat`
- `hlsVideoSegmentFormat` → `setHlsVideoSegmentFormat`

Two small helpers map the Flutter enum names to the CAF string values the
receiver expects (`fmp4`, `ts_aac`, `e-ac3`, `mpeg2_ts`, …); unknown / `none`
values are left unset. `setHlsSegmentFormat`/`setHlsVideo
`String` in `play-services-cast-framework:21.5.0`.
| Field                  | Dart (toMap) | iOS | Android (before) | Android (after) |
|------------------------|:------------:|:---:|:----------------:|:---------------:|
| streamDuration         | ✅           | ✅  | ❌               | ✅              |
| hlsSegmentFormat       | ✅           | ✅  | ❌               | ✅              |
| hlsVideoSegmentFormat  | ✅           | ✅  | ❌               | ✅              |

## Testing

- Casting an fMP4 HLS VOD to a Default Media Receiver: previously stuck in
  `LOADING`, now plays correctly.
- Non-HLS / progressive MP4 streams: unchanged (fields left unset).
- Android-only change; no Dart or iOS code touched.