### PR TITLE
support for arm64 architecture on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.4.7 - iOS arm64 Simulator Support
+### 🔧 Platform Improvements
+- **Apple Silicon / iOS 26+ simulators**: Ensured the plugin no longer excludes `arm64` for `iphonesimulator`.
+  - CocoaPods dependency pinned to `google-cast-sdk` `~> 4.8.4` (XCFramework with arm64 simulator slices).
+  - Removed reliance on `google-cast-sdk-no-bluetooth`, which forces `EXCLUDED_ARCHS[sdk=iphonesimulator*]=arm64`.
+  - SPM Google Cast wrapper bumped to `4.8.4+` for the same XCFramework slices.
+
+### 🔧 Notes
+- Apps that previously cached CocoaPods artifacts for `google-cast-sdk-no-bluetooth` should clean `ios/Pods` and re-run `flutter pub get` / `pod install` so Flutter stops writing `EXCLUDED_ARCHS=arm64` into `Generated.xcconfig`.
+
 ## 1.4.6 - iOS Force Session Reset
 ### New Features
 - Added `resetSession()` to force a clean iOS Cast session reset after interrupted or stuck connections.

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
         // Google Cast SDK wrapper maintained by SRGSSR (Swiss Radio and Television)
         // This is a community-maintained wrapper that provides SPM support for the official Google Cast SDK.
         // Check https://github.com/SRGSSR/google-cast-sdk for the latest version tag and release notes.
-        .package(url: "https://github.com/SRGSSR/google-cast-sdk.git", from: "4.8.3")
+        // 4.8.4+ XCFramework includes arm64 + x86_64 simulator slices (Apple Silicon / iOS 26+).
+        .package(url: "https://github.com/SRGSSR/google-cast-sdk.git", from: "4.8.4")
     ],
     targets: [
         .target(

--- a/ios/flutter_chrome_cast.podspec
+++ b/ios/flutter_chrome_cast.podspec
@@ -5,9 +5,14 @@
 # This plugin supports both CocoaPods (this file) and Swift Package Manager (Package.swift).
 # For SPM support, see flutter_chrome_cast/Package.swift.
 #
+# arm64 iOS Simulator:
+# - Do NOT set EXCLUDED_ARCHS for iphonesimulator (required for Apple Silicon / iOS 26+ sims).
+# - Depend on google-cast-sdk >= 4.8.4, which ships an XCFramework with ios-arm64 simulator slices.
+# - Do NOT use google-cast-sdk-no-bluetooth; that pod excludes arm64 simulator architectures.
+#
 Pod::Spec.new do |s|
   s.name             = 'flutter_chrome_cast'
-  s.version          = '1.4.1'
+  s.version          = '1.4.7'
   s.summary          = 'A comprehensive Flutter plugin for Google Cast SDK integration on iOS and Android.'
   s.description      = <<-DESC
 FlutterGoogleCast provides seamless integration with the Google Cast SDK for Flutter applications.
@@ -25,15 +30,18 @@ This plugin supports both CocoaPods and Swift Package Manager (SPM) for iOS depe
   s.dependency 'Flutter'
   s.platform = :ios, '15.0'
   s.ios.deployment_target  = '15.0'
-  s.dependency 'google-cast-sdk', '~> 4.8'
+  # 4.8.4+ XCFramework includes arm64 simulator; required for Apple Silicon iOS 26+ simulators.
+  s.dependency 'google-cast-sdk', '~> 4.8.4'
   s.dependency 'Protobuf'
   s.static_framework = true
 
-  s.pod_target_xcconfig = { 
+  # Intentionally no EXCLUDED_ARCHS — arm64 simulator must remain enabled.
+  s.pod_target_xcconfig = {
     'ENABLE_TESTING_SEARCH_PATHS' => 'YES',
-    'DEFINES_MODULE' => 'YES'
+    'DEFINES_MODULE' => 'YES',
+    'ONLY_ACTIVE_ARCH[sdk=iphonesimulator*]' => 'YES'
   }
-  s.user_target_xcconfig = { 
+  s.user_target_xcconfig = {
     'ENABLE_TESTING_SEARCH_PATHS' => 'YES'
   }
 

--- a/ios/flutter_chrome_cast/Package.swift
+++ b/ios/flutter_chrome_cast/Package.swift
@@ -24,7 +24,8 @@ let package = Package(
         // Google Cast SDK wrapper maintained by SRGSSR (Swiss Radio and Television)
         // This is a community-maintained wrapper that provides SPM support for the official Google Cast SDK.
         // Check https://github.com/SRGSSR/google-cast-sdk for the latest version tag and release notes.
-        .package(url: "https://github.com/SRGSSR/google-cast-sdk.git", from: "4.8.3")
+        // 4.8.4+ XCFramework includes arm64 + x86_64 simulator slices (Apple Silicon / iOS 26+).
+        .package(url: "https://github.com/SRGSSR/google-cast-sdk.git", from: "4.8.4")
     ],
     targets: [
         .target(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chrome_cast
 description: A Flutter plugin for integrating Google Cast devices. Discover, connect, and control media playback on Chromecast and Cast-enabled devices.
-version: 1.4.6
+version: 1.4.7
 repository: https://github.com/felnanuke2/flutter_google_cast
 license: BSD-3-Clause
 


### PR DESCRIPTION
This fixed #79 

Added support for ios arm64 as required by latest version of xcode simulator