### PR TITLE
fix(ios): use canonical Cast metadata keys for title and subtitle

### DIFF
--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaMetatadaExtensions.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaMetatadaExtensions.swift
@@ -94,7 +94,18 @@ extension GCKMediaMetadata {
         for mapValue in mutableDict{
             switch mapValue.value {
             case let stringValue as String:
-                metadata.setString(stringValue, forKey: mapValue.key)
+                // Standard fields must use Google's metadata keys — a raw
+                // "title" is stored as a custom field and the receiver, which
+                // reads kGCKMetadataKeyTitle, never displays it. Anything not
+                // recognised keeps its own key so custom metadata still works.
+                switch mapValue.key {
+                case "title":
+                    metadata.setString(stringValue, forKey: kGCKMetadataKeyTitle)
+                case "subtitle":
+                    metadata.setString(stringValue, forKey: kGCKMetadataKeySubtitle)
+                default:
+                    metadata.setString(stringValue, forKey: mapValue.key)
+                }
             case let intValue as Int:
                 metadata.setInteger(intValue, forKey: mapValue.key)
             case let doubleValue as Double:


### PR DESCRIPTION
GCKMediaMetadata entries were written under the raw key names coming from Dart, so `title` was stored as a custom "title" field rather than under kGCKMetadataKeyTitle ("com.google.cast.metadata.TITLE"). The receiver reads the canonical key, so media played but was never captioned.

Unrecognised keys keep their own name, so custom metadata is unaffected.

Verified on an NVIDIA Shield running the Default Media Receiver from iOS 26.6: with this change a title supplied through
GoogleCastGenericMediaMetadata appears on the casting screen; without it, nothing is shown.