### PR TITLE
fix(ios): map all standard metadata keys to canonical Cast keys

### DIFF
--- a/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaMetatadaExtensions.swift
+++ b/ios/flutter_chrome_cast/Sources/flutter_chrome_cast/Extensions/MediaMetatadaExtensions.swift
@@ -11,6 +11,30 @@ import GoogleCast
 
 
 extension GCKMediaMetadata {
+    /// Maps raw Dart keys to Google Cast canonical metadata keys. Standard
+    /// fields sent under their JSON names would be stored as custom fields,
+    /// which receivers never display. Unrecognised keys keep their own name
+    /// so custom metadata still works.
+    private static let canonicalKeys: [String: String] = [
+        "title": kGCKMetadataKeyTitle,
+        "subtitle": kGCKMetadataKeySubtitle,
+        "artist": kGCKMetadataKeyArtist,
+        "albumArtist": kGCKMetadataKeyAlbumArtist,
+        "albumName": kGCKMetadataKeyAlbumTitle,
+        "composer": kGCKMetadataKeyComposer,
+        "studio": kGCKMetadataKeyStudio,
+        "seriesTitle": kGCKMetadataKeySeriesTitle,
+        "season": kGCKMetadataKeySeasonNumber,
+        "episode": kGCKMetadataKeyEpisodeNumber,
+        "trackNumber": kGCKMetadataKeyTrackNumber,
+        "discNumber": kGCKMetadataKeyDiscNumber,
+        "location": kGCKMetadataKeyLocationName,
+        "latitude": kGCKMetadataKeyLocationLatitude,
+        "longitude": kGCKMetadataKeyLocationLongitude,
+        "width": kGCKMetadataKeyWidth,
+        "height": kGCKMetadataKeyHeight,
+    ]
+
     func toMap() -> Dictionary<String,Any?> {
         var dict = Dictionary<String,Any?>()
         dict["type"] = self.metadataType.rawValue
@@ -92,24 +116,14 @@ extension GCKMediaMetadata {
         
       
         for mapValue in mutableDict{
+            let key = GCKMediaMetadata.canonicalKeys[mapValue.key] ?? mapValue.key
             switch mapValue.value {
             case let stringValue as String:
-                // Standard fields must use Google's metadata keys — a raw
-                // "title" is stored as a custom field and the receiver, which
-                // reads kGCKMetadataKeyTitle, never displays it. Anything not
-                // recognised keeps its own key so custom metadata still works.
-                switch mapValue.key {
-                case "title":
-                    metadata.setString(stringValue, forKey: kGCKMetadataKeyTitle)
-                case "subtitle":
-                    metadata.setString(stringValue, forKey: kGCKMetadataKeySubtitle)
-                default:
-                    metadata.setString(stringValue, forKey: mapValue.key)
-                }
+                metadata.setString(stringValue, forKey: key)
             case let intValue as Int:
-                metadata.setInteger(intValue, forKey: mapValue.key)
+                metadata.setInteger(intValue, forKey: key)
             case let doubleValue as Double:
-                 metadata.setDouble(doubleValue, forKey: mapValue.key)
+                 metadata.setDouble(doubleValue, forKey: key)
             default:
                 break
             }
@@ -121,7 +135,7 @@ extension GCKMediaMetadata {
                     metadata.setDate(date, forKey: kGCKMetadataKeyBroadcastDate)
                 case "releaseDate":
                     metadata.setDate(date, forKey: kGCKMetadataKeyReleaseDate)
-                case "creationDate":
+                case "creationDate", "creationDateTime":
                     metadata.setDate(date, forKey: kGCKMetadataKeyCreationDate)
                 default:
                     break


### PR DESCRIPTION
Follow-up to #83, which fixed `title`/`subtitle` only. The same bug affects every other standard field the Dart API exposes.

## What changed

- Replaces the title/subtitle-only switch in `GCKMediaMetadata.fromMap` with a single `canonicalKeys` translation table applied **before** the type switch, so it covers String, Int and Double values alike
- Maps: `artist`, `albumArtist`, `albumName` → `kGCKMetadataKeyAlbumTitle`, `composer`, `studio`, `seriesTitle`, `season`/`episode`/`trackNumber`/`discNumber` (Int), `location` → `kGCKMetadataKeyLocationName`, `latitude`/`longitude` (Double), `width`/`height`
- Accepts `creationDateTime` as a date key, matching what `GoogleCastPhotoMediaMetadata` sends — photo creation dates were silently dropped on iOS (Android already handles this key)
- Unrecognised keys keep their own name, so custom metadata is unaffected

## Not addressed here (separate PRs welcome)

- Android `GoogleCastMetadataBuilder` has the identical raw-key bug (`MetadataExtensions.kt`)
- Reverse direction: iOS `toMap()` emits `serieTitle`/`seasonNumber`/`episodeNumber`/`albumTitle` while Dart expects `seriesTitle`/`season`/`episode`/`albumName`